### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -74,5 +74,5 @@ Call ``chmod 600 ~/.netrc`` afterwards, to protect your sensitive data.
 .. _`deck2pdf`: https://github.com/melix/deck2pdf
 .. _`impress.js`: https://github.com/impress/impress.js
 .. _`reStructuredText`: http://docutils.sourceforge.net/rst.html
-.. _`Hovercraft!`: https://hovercraft.readthedocs.org/
+.. _`Hovercraft!`: https://hovercraft.readthedocs.io/
 .. _`Artifactory`: https://www.jfrog.com/artifactory/

--- a/{{cookiecutter.repo_name}}/index.rst
+++ b/{{cookiecutter.repo_name}}/index.rst
@@ -224,5 +224,5 @@ Credits
 
 *[Licensing conditions of the original projects apply]*
 
-.. _`Hovercraft!`: http://hovercraft.readthedocs.org/
+.. _`Hovercraft!`: https://hovercraft.readthedocs.io/
 .. _`Cookiecutter`: https://github.com/audreyr/cookiecutter


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
